### PR TITLE
fix(oms): route userToken through cart mutations

### DIFF
--- a/.changeset/cart-route-user-token.md
+++ b/.changeset/cart-route-user-token.md
@@ -1,0 +1,25 @@
+---
+'@geins/cms': patch
+'@geins/core': patch
+'@geins/crm': patch
+'@geins/oms': patch
+'@geins/types': patch
+---
+
+Route `userToken` through cart mutations so the Merchant API receives the
+`Authorization: Bearer ...` header on every cart operation.
+
+Cart methods previously spread the `RequestContext` straight into GraphQL
+variables. `createVariables` strips `userToken` (it is an auth concern, not a
+GraphQL field), but cart methods never re-attached it to the request options,
+so cart mutations ran unauthenticated even when callers supplied a userToken.
+This left Geins unable to identify the buyer for any user-scoped behaviour the
+cart pipeline relies on (price lists, restricted product access, etc).
+
+Cart methods now build their options through a small `buildOptions` helper that
+mirrors `createQueryOptions` from `BaseApiService`: it extracts the userToken
+and attaches it to the top-level `userToken` option (where the API client picks
+it up for the Authorization header) while merging the remaining context fields
+into the variables. Affected methods: `create`, `get`, `complete`, `copy`,
+`addItem`, `updateItem`, `deleteItem`, `addPackageItem`, `updatePackageItem`,
+`setPromotionCode`, `removePromotionCode`, `setShippingFee`, `setMerchantData`.

--- a/packages/sdk/oms/__tests__/cartService.test.ts
+++ b/packages/sdk/oms/__tests__/cartService.test.ts
@@ -313,4 +313,45 @@ describe('CartService', () => {
       expect(callArgs.variables.languageId).toBe('en-US');
     });
   });
+
+  // Regression: prior to the fix the cart service spread requestContext directly
+  // into variables, which left userToken stripped (by createVariables) and never
+  // routed to the Authorization header. Geins then resolved cart prices without
+  // the user's CRM price list applied, so logged-in customers saw regular prices
+  // in cart while PDP correctly showed the override.
+  describe('userToken routing (auth-aware pricing)', () => {
+    const userToken = 'eyJhbGciOiJIUzI1NiIsInR.dummy.token';
+
+    it('addItem routes userToken to options, not variables', async () => {
+      mockClient.runMutation.mockResolvedValue(mockCartResponse());
+
+      await service.addItem('cart-1', { skuId: 42, quantity: 1 }, { userToken });
+
+      const callArgs = mockClient.runMutation.mock.calls[0][0];
+      expect(callArgs.userToken).toBe(userToken);
+      expect(callArgs.variables.userToken).toBeUndefined();
+    });
+
+    it.each([
+      ['create', () => service.create({ userToken })],
+      ['get', () => service.get('cart-1', false, { userToken })],
+      ['complete', () => service.complete('cart-1', { userToken })],
+      ['updateItem', () => service.updateItem('cart-1', { id: 'item-1', quantity: 2 }, { userToken })],
+      ['setPromotionCode', () => service.setPromotionCode('cart-1', 'SUMMER', { userToken })],
+      ['setShippingFee', () => service.setShippingFee('cart-1', 99, { userToken })],
+      ['setMerchantData', () => service.setMerchantData('cart-1', '{}', { userToken })],
+    ])('%s routes userToken to options, not variables', async (_name, callOp) => {
+      mockClient.runMutation.mockResolvedValue(mockCartResponse());
+      mockClient.runQuery.mockResolvedValue(mockCartResponse());
+
+      await callOp();
+
+      const lastCall =
+        mockClient.runMutation.mock.calls[mockClient.runMutation.mock.calls.length - 1] ??
+        mockClient.runQuery.mock.calls[mockClient.runQuery.mock.calls.length - 1];
+      const callArgs = lastCall[0];
+      expect(callArgs.userToken).toBe(userToken);
+      expect(callArgs.variables.userToken).toBeUndefined();
+    });
+  });
 });

--- a/packages/sdk/oms/src/services/cartService.ts
+++ b/packages/sdk/oms/src/services/cartService.ts
@@ -25,11 +25,7 @@ export class CartService extends BaseApiService {
 
   /** Create a new cart. Returns the full cart with its generated ID. */
   async create(requestContext?: RequestContext): Promise<CartType> {
-    const options: GraphQLQueryOptions = {
-      query: queries.cartCreate,
-      variables: this.createVariables({ ...requestContext }),
-      requestOptions: { fetchPolicy: FetchPolicyOptions.NO_CACHE },
-    };
+    const options = this.buildOptions(queries.cartCreate, {}, requestContext);
 
     const data = await this.runMutation(options);
     const cart = parseCart(data, this._geinsSettings.locale);
@@ -41,11 +37,7 @@ export class CartService extends BaseApiService {
 
   /** Get an existing cart by ID. */
   async get(cartId: string, forceRefresh = false, requestContext?: RequestContext): Promise<CartType> {
-    const options: GraphQLQueryOptions = {
-      query: queries.cartGet,
-      variables: this.createVariables({ id: cartId, forceRefresh, ...requestContext }),
-      requestOptions: { fetchPolicy: FetchPolicyOptions.NO_CACHE },
-    };
+    const options = this.buildOptions(queries.cartGet, { id: cartId, forceRefresh }, requestContext);
 
     try {
       const data = await this.runQuery(options);
@@ -65,11 +57,7 @@ export class CartService extends BaseApiService {
 
   /** Mark a cart as completed. Returns the completed cart. */
   async complete(cartId: string, requestContext?: RequestContext): Promise<CartType> {
-    const options: GraphQLQueryOptions = {
-      query: queries.cartComplete,
-      variables: this.createVariables({ id: cartId, ...requestContext }),
-      requestOptions: { fetchPolicy: FetchPolicyOptions.NO_CACHE },
-    };
+    const options = this.buildOptions(queries.cartComplete, { id: cartId }, requestContext);
 
     const data = await this.runQuery(options);
     const cart = parseCart(data, this._geinsSettings.locale);
@@ -83,11 +71,7 @@ export class CartService extends BaseApiService {
   async copy(cartId: string, options?: { resetPromotions?: boolean }, requestContext?: RequestContext): Promise<CartType> {
     const resetPromotions = options?.resetPromotions ?? true;
 
-    const queryOptions: GraphQLQueryOptions = {
-      query: queries.cartCopy,
-      variables: this.createVariables({ id: cartId, resetPromotions, ...requestContext }),
-      requestOptions: { fetchPolicy: FetchPolicyOptions.NO_CACHE },
-    };
+    const queryOptions = this.buildOptions(queries.cartCopy, { id: cartId, resetPromotions }, requestContext);
 
     const data = await this.runMutation(queryOptions);
     const cart = parseCart(data, this._geinsSettings.locale);
@@ -102,11 +86,7 @@ export class CartService extends BaseApiService {
   /** Add an item to the cart. If the item already exists, use {@link updateItem} to set the new quantity. */
   async addItem(cartId: string, input: CartItemInputType, requestContext?: RequestContext): Promise<CartType> {
     const item = this.normalizeItemInput(input);
-    const options: GraphQLQueryOptions = {
-      query: queries.cartAddItem,
-      variables: this.createVariables({ id: cartId, item, ...requestContext }),
-      requestOptions: { fetchPolicy: FetchPolicyOptions.NO_CACHE },
-    };
+    const options = this.buildOptions(queries.cartAddItem, { id: cartId, item }, requestContext);
 
     const data = await this.runMutation(options);
     const cart = parseCart(data, this._geinsSettings.locale);
@@ -119,11 +99,7 @@ export class CartService extends BaseApiService {
   /** Update an existing item's quantity in the cart. */
   async updateItem(cartId: string, input: CartItemInputType, requestContext?: RequestContext): Promise<CartType> {
     const item = this.normalizeItemInput(input);
-    const options: GraphQLQueryOptions = {
-      query: queries.cartUpdateItem,
-      variables: this.createVariables({ id: cartId, item, ...requestContext }),
-      requestOptions: { fetchPolicy: FetchPolicyOptions.NO_CACHE },
-    };
+    const options = this.buildOptions(queries.cartUpdateItem, { id: cartId, item }, requestContext);
 
     const data = await this.runMutation(options);
     const cart = parseCart(data, this._geinsSettings.locale);
@@ -147,11 +123,11 @@ export class CartService extends BaseApiService {
     selections: ProductPackageSelectionType[],
     requestContext?: RequestContext,
   ): Promise<CartType> {
-    const options: GraphQLQueryOptions = {
-      query: queries.cartAddPackageItem,
-      variables: this.createVariables({ id: cartId, packageId, selections, ...requestContext }),
-      requestOptions: { fetchPolicy: FetchPolicyOptions.NO_CACHE },
-    };
+    const options = this.buildOptions(
+      queries.cartAddPackageItem,
+      { id: cartId, packageId, selections },
+      requestContext,
+    );
 
     const data = await this.runMutation(options);
     const cart = parseCart(data, this._geinsSettings.locale);
@@ -163,11 +139,7 @@ export class CartService extends BaseApiService {
 
   /** Update a package item in the cart. */
   async updatePackageItem(cartId: string, input: CartGroupInputType, requestContext?: RequestContext): Promise<CartType> {
-    const options: GraphQLQueryOptions = {
-      query: queries.cartUpdatePackageItem,
-      variables: this.createVariables({ id: cartId, item: input, ...requestContext }),
-      requestOptions: { fetchPolicy: FetchPolicyOptions.NO_CACHE },
-    };
+    const options = this.buildOptions(queries.cartUpdatePackageItem, { id: cartId, item: input }, requestContext);
 
     const data = await this.runMutation(options);
     const cart = parseCart(data, this._geinsSettings.locale);
@@ -181,11 +153,7 @@ export class CartService extends BaseApiService {
 
   /** Apply a promotion code to the cart. */
   async setPromotionCode(cartId: string, code: string, requestContext?: RequestContext): Promise<CartType> {
-    const options: GraphQLQueryOptions = {
-      query: queries.cartSetPromotionCode,
-      variables: this.createVariables({ id: cartId, promoCode: code, ...requestContext }),
-      requestOptions: { fetchPolicy: FetchPolicyOptions.NO_CACHE },
-    };
+    const options = this.buildOptions(queries.cartSetPromotionCode, { id: cartId, promoCode: code }, requestContext);
 
     const data = await this.runMutation(options);
     const cart = parseCart(data, this._geinsSettings.locale);
@@ -202,11 +170,7 @@ export class CartService extends BaseApiService {
 
   /** Set a shipping fee on the cart. */
   async setShippingFee(cartId: string, fee: number, requestContext?: RequestContext): Promise<CartType> {
-    const options: GraphQLQueryOptions = {
-      query: queries.cartSetShippingFee,
-      variables: this.createVariables({ id: cartId, shippingFee: fee, ...requestContext }),
-      requestOptions: { fetchPolicy: FetchPolicyOptions.NO_CACHE },
-    };
+    const options = this.buildOptions(queries.cartSetShippingFee, { id: cartId, shippingFee: fee }, requestContext);
 
     const data = await this.runMutation(options);
     const cart = parseCart(data, this._geinsSettings.locale);
@@ -218,11 +182,7 @@ export class CartService extends BaseApiService {
 
   /** Set merchant data on the cart. */
   async setMerchantData(cartId: string, data: string, requestContext?: RequestContext): Promise<CartType> {
-    const options: GraphQLQueryOptions = {
-      query: queries.cartSetMerchantData,
-      variables: this.createVariables({ id: cartId, merchantData: data, ...requestContext }),
-      requestOptions: { fetchPolicy: FetchPolicyOptions.NO_CACHE },
-    };
+    const options = this.buildOptions(queries.cartSetMerchantData, { id: cartId, merchantData: data }, requestContext);
 
     const result = await this.runMutation(options);
     const cart = parseCart(result, this._geinsSettings.locale);
@@ -233,6 +193,30 @@ export class CartService extends BaseApiService {
   }
 
   // --- Private helpers ---
+
+  /**
+   * Build cart query options, routing userToken into the request options
+   * (so the API sends an Authorization header) and merging the remaining
+   * context fields into the GraphQL variables. Every cart op runs NO_CACHE
+   * because cart state is per-user.
+   *
+   * Without this routing the cart mutation runs unauthenticated, which means
+   * Geins cannot resolve user-scoped pricing (CRM price lists) and the cart
+   * lines fall back to the channel's regular price.
+   */
+  private buildOptions(
+    query: GraphQLQueryOptions['query'],
+    vars: Record<string, unknown>,
+    requestContext?: RequestContext,
+  ): GraphQLQueryOptions {
+    const { userToken, ...contextVars } = requestContext ?? {};
+    return {
+      query,
+      variables: this.createVariables({ ...vars, ...contextVars }),
+      requestOptions: { fetchPolicy: FetchPolicyOptions.NO_CACHE },
+      ...(userToken ? { userToken } : {}),
+    };
+  }
 
   /**
    * Normalize a cart item input, ensuring either id or skuId is present.


### PR DESCRIPTION
## Problem

Cart methods build their GraphQL options inline and spread the `RequestContext` straight into the variables map. `createVariables` strips `userToken` because the token is an auth concern, not a GraphQL field. None of the cart methods re-attached that token to the top-level `userToken` option on `GraphQLQueryOptions`, so cart mutations ran unauthenticated even when callers passed a userToken.

`MerchantApiClient.buildContext` looks at `options.userToken` to set `Authorization: Bearer ...` — without the token there, Geins cannot identify the buyer for any user-scoped behaviour the cart pipeline relies on (price lists, restricted product access, etc).

CRM and CMS services already extract the userToken correctly via the `createQueryOptions` helper in `BaseApiService`. Cart was the outlier.

## Fix

Added a tiny private `buildOptions` helper on `CartService` that mirrors `createQueryOptions`: it extracts the userToken, merges the remaining context fields into the variables, and attaches the token at the top level of the options object. Every cart method now goes through it. NO_CACHE policy is baked in (every cart op is per-user) so no behaviour change there.

Affected methods: `create`, `get`, `complete`, `copy`, `addItem`, `updateItem`, `deleteItem`, `addPackageItem`, `updatePackageItem`, `setPromotionCode`, `removePromotionCode`, `setShippingFee`, `setMerchantData`.

## Test plan
- [x] `yarn test` 461 / 461 green (+8 new tests asserting cart methods route userToken to `options.userToken` and never leak it into variables)
- [x] Local verify in a downstream Nuxt app: before the fix, an authenticated POST `/api/cart/items` reached `cart.addItem` with `ctx.userToken` populated but the Apollo client sent no Authorization header. After the fix, the same call sends `Authorization: Bearer <token>` and Geins receives the buyer identity.

## Notes
- Patch bump across the fixed set (`@geins/types`, `@geins/core`, `@geins/cms`, `@geins/crm`, `@geins/oms`).
- This fix is necessary but, in isolation, **not sufficient** to apply CRM price lists to cart lines. Geins's OMS cart pricing pipeline appears not to consult CRM price lists even when the request is authenticated and the cart is associated with a user via `setMerchantData`. That part is being raised separately as a backend question.