### PR TITLE
feat(crm): expose availableChannels on the user response

### DIFF
--- a/.changeset/user-available-channels.md
+++ b/.changeset/user-available-channels.md
@@ -1,0 +1,33 @@
+---
+"@geins/types": patch
+"@geins/core": patch
+"@geins/cms": patch
+"@geins/crm": patch
+"@geins/oms": patch
+---
+
+Surface `availableChannels` on the user response from `crm.user.get()`.
+
+The merchant API exposes `UserType.availableChannels` returning the channels
+a buyer is authorized to use, with the markets allowed per channel and each
+market's currency. Storefronts need this on login to switch the active
+market to one the buyer is permitted on. Passing a channel or market the
+buyer is not allowed to use can return empty or invalid catalog responses,
+which is the failure mode B2B portals were hitting when the active market
+mismatched the company's pricelist currency.
+
+The user GraphQL fragment now selects:
+
+```graphql
+availableChannels {
+  channelId
+  availableMarkets {
+    id
+    alias
+    currency { code }
+  }
+}
+```
+
+`UserChannelType` is added to the schema and `availableChannels` is
+exposed on `GeinsUserTypeType` via the generated types.

--- a/packages/sdk/crm/src/graphql/fragments/user.gql
+++ b/packages/sdk/crm/src/graphql/fragments/user.gql
@@ -13,4 +13,14 @@ fragment User on UserType {
     ...UserBalance
   }
   metaData
+  availableChannels {
+    channelId
+    availableMarkets {
+      id
+      alias
+      currency {
+        code
+      }
+    }
+  }
 }

--- a/packages/sdk/types/src/generated/graphql.ts
+++ b/packages/sdk/types/src/generated/graphql.ts
@@ -2237,6 +2237,19 @@ export interface GeinsUserBalanceTypeType {
   currency: Scalars['String']['output'];
 }
 
+/**
+ * Pair of channel id and the markets the user is allowed to use on that channel.
+ * Used by storefronts to switch the active market/currency to one the buyer is
+ * authorized for before making any subsequent API calls. Passing a market the
+ * buyer is not allowed to use can return empty or invalid catalog responses.
+ */
+export interface GeinsUserChannelTypeType {
+  /** The markets the user is allowed to use on this channel. */
+  availableMarkets?: Maybe<Array<Maybe<GeinsMarketTypeType>>>;
+  /** The channel identifier the user has access to. */
+  channelId: Scalars['String']['output'];
+}
+
 export interface GeinsUserInputTypeType {
   address?: InputMaybe<GeinsAddressInputTypeType>;
   customerType?: InputMaybe<GeinsCustomerType>;
@@ -2250,6 +2263,8 @@ export interface GeinsUserInputTypeType {
 export interface GeinsUserTypeType {
   /** The address of the user. */
   address?: Maybe<GeinsAddressTypeType>;
+  /** Channels the user is allowed to use, with the markets allowed per channel. */
+  availableChannels?: Maybe<Array<Maybe<GeinsUserChannelTypeType>>>;
   /**
    * Account balance
    * @deprecated Use Balances instead
@@ -2777,6 +2792,16 @@ export type GeinsUserType = {
   balances?: Array<{
     currency: string,
     amount: number
+  } | null> | null,
+  availableChannels?: Array<{
+    channelId: string,
+    availableMarkets?: Array<{
+      id: string,
+      alias?: string | null,
+      currency?: {
+        code: string
+      } | null
+    } | null> | null
   } | null> | null
 };
 
@@ -4449,6 +4474,16 @@ export type GeinsUserGetType = {
     balances?: Array<{
       currency: string,
       amount: number
+    } | null> | null,
+    availableChannels?: Array<{
+      channelId: string,
+      availableMarkets?: Array<{
+        id: string,
+        alias?: string | null,
+        currency?: {
+          code: string
+        } | null
+      } | null> | null
     } | null> | null
   } | null
 };
@@ -4502,6 +4537,16 @@ export type GeinsUserUpdateType = {
     balances?: Array<{
       currency: string,
       amount: number
+    } | null> | null,
+    availableChannels?: Array<{
+      channelId: string,
+      availableMarkets?: Array<{
+        id: string,
+        alias?: string | null,
+        currency?: {
+          code: string
+        } | null
+      } | null> | null
     } | null> | null
   } | null
 };
@@ -9958,6 +10003,16 @@ export type GeinsGetOrderPublicType = {
  */
 
 /**
+ * Pair of channel id and the markets the user is allowed to use on that channel.
+ * Used by storefronts to switch the active market/currency to one the buyer is
+ * authorized for before making any subsequent API calls. Passing a market the
+ * buyer is not allowed to use can return empty or invalid catalog responses.
+ * @typedef {Object} UserChannelType
+ * @property {Array<(MarketType|null|undefined)>} [availableMarkets] - The markets the user is allowed to use on this channel.
+ * @property {string} channelId - The channel identifier the user has access to.
+ */
+
+/**
  * @typedef {Object} UserInputType
  * @property {AddressInputType} [address]
  * @property {CustomerType} [customerType]
@@ -9970,6 +10025,7 @@ export type GeinsGetOrderPublicType = {
 /**
  * @typedef {Object} UserType
  * @property {AddressType} [address] - The address of the user.
+ * @property {Array<(UserChannelType|null|undefined)>} [availableChannels] - Channels the user is allowed to use, with the markets allowed per channel.
  * @property {Decimal} balance - Account balance - DEPRECATED: Use Balances instead
  * @property {string} [balanceFormatted] - Account balance. Formatted as a currency string. - DEPRECATED: Use Balances instead
  * @property {Array<(UserBalanceType|null|undefined)>} [balances] - User balance per currency

--- a/schemas/schema-w-docblocks.graphql
+++ b/schemas/schema-w-docblocks.graphql
@@ -3121,6 +3121,20 @@ type UserBalanceType {
   amountFormatted: String
 }
 
+"""
+Pair of channel id and the markets the user is allowed to use on that channel.
+Used by storefronts to switch the active market/currency to one the buyer is
+authorized for before making any subsequent API calls. Passing a market the
+buyer is not allowed to use can return empty or invalid catalog responses.
+"""
+type UserChannelType {
+  """The channel identifier the user has access to."""
+  channelId: String!
+
+  """The markets the user is allowed to use on this channel."""
+  availableMarkets: [MarketType]
+}
+
 input UserInputType {
   address: AddressInputType
   gender: Gender
@@ -3173,6 +3187,9 @@ type UserType {
   Free-text field that can contain any additional metadata related to the customer.
   """
   metaData: String
+
+  """Channels the user is allowed to use, with the markets allowed per channel."""
+  availableChannels: [UserChannelType]
 }
 
 type ValidateOrderConditionsResponseType {

--- a/schemas/schema.graphql
+++ b/schemas/schema.graphql
@@ -3121,6 +3121,20 @@ type UserBalanceType {
   amountFormatted: String
 }
 
+"""
+Pair of channel id and the markets the user is allowed to use on that channel.
+Used by storefronts to switch the active market/currency to one the buyer is
+authorized for before making any subsequent API calls. Passing a market the
+buyer is not allowed to use can return empty or invalid catalog responses.
+"""
+type UserChannelType {
+  """The channel identifier the user has access to."""
+  channelId: String!
+
+  """The markets the user is allowed to use on this channel."""
+  availableMarkets: [MarketType]
+}
+
 input UserInputType {
   address: AddressInputType
   gender: Gender
@@ -3173,6 +3187,9 @@ type UserType {
   Free-text field that can contain any additional metadata related to the customer.
   """
   metaData: String
+
+  """Channels the user is allowed to use, with the markets allowed per channel."""
+  availableChannels: [UserChannelType]
 }
 
 type ValidateOrderConditionsResponseType {


### PR DESCRIPTION
## Summary

- Adds `UserType.availableChannels` to the schema and the User fragment.
- `crm.user.get()` now returns `availableChannels` with the channels a buyer is allowed to use, the markets per channel, and each market's currency.
- Regenerates `@geins/types`.

## Why

Storefronts need this on login to switch the active market to one the buyer is permitted on. Passing a channel or market the buyer is not allowed to use can return empty or invalid catalog responses, which is the failure mode B2B portals were hitting when the active market mismatched the company's pricelist currency.

The fragment selects the minimum needed shape:

\`\`\`graphql
availableChannels {
  channelId
  availableMarkets {
    id
    alias
    currency { code }
  }
}
\`\`\`

## Test plan

- [x] \`yarn build\` clean (6/6 tasks)
- [x] \`yarn test\` green (463/463)
- [ ] Sales-portal consumer (separate PR) exercises the new field on staging