### PR TITLE
test(oms): make applied-campaign test deterministic via promo code

### DIFF
--- a/packages/sdk/oms/__tests__/GeinsOMS.cart.test.ts
+++ b/packages/sdk/oms/__tests__/GeinsOMS.cart.test.ts
@@ -147,9 +147,12 @@ describe('GeinsOMS cart (stateless)', () => {
 
   it('should show applied campaign', async () => {
     let cart = await geinsOMS.cart.create();
-    cart = await geinsOMS.cart.addItem(cart.id, { skuId: omsSettings.skus.skuId1, quantity: 1 });
     cart = await geinsOMS.cart.addItem(cart.id, { skuId: omsSettings.skus.skuId2, quantity: 1 });
-    cart = await geinsOMS.cart.addItem(cart.id, { skuId: omsSettings.skus.skuId3, quantity: 1 });
+
+    // Apply a known promotion code so a campaign is deterministically present.
+    // Relying on an always-on automatic campaign made this test depend on live
+    // promo configuration and flake when none was active.
+    cart = await geinsOMS.cart.setPromotionCode(cart.id, omsSettings.promotionCodes.percentOff);
 
     expect(cart.appliedCampaigns?.length ?? 0).toBeGreaterThan(0);
   });


### PR DESCRIPTION
## What

`GeinsOMS.cart.test.ts > should show applied campaign` no longer relies on an always-on automatic campaign for the test SKUs. It now applies the configured promotion code (the same one the sibling `should apply and remove promotion code` test uses) and asserts that `appliedCampaigns` is populated.

## Why

The old assertion depended on live promo configuration in the test account. When no automatic campaign was active for those SKUs, the test failed, which red-lined `yarn test` and blocked the Packages Release and Canary workflows (those run `yarn test` before publishing). This makes the test deterministic without changing any product code.

## Verification

Ran the test against the live account: passes (campaign applied via promo code). Lint clean. No source changes.

## Notes

Test-only change, no consumer impact, so no changeset.